### PR TITLE
fix conflict between library during build

### DIFF
--- a/Prepare_toolchain.sh
+++ b/Prepare_toolchain.sh
@@ -11,7 +11,7 @@ apt-get -y --no-install-recommends --fix-missing install \
 	bsdtar mtools u-boot-tools pv bc \
 	gcc automake make \
 	lib32z1 lib32z1-dev qemu-user-static \
-	dosfstools libncurses5-dev lib32stdc++ debootstrap
+	dosfstools libncurses5-dev lib32stdc++6 debootstrap
 
 # Prepare toolchains
 ROOT=`cd .. && pwd`


### PR DESCRIPTION
apt-get lib32stdc++ failed with library conflict. Specify library version(lib32stdc++6) resolve this problem.
Tested on ubuntu xenial x86_64.